### PR TITLE
feat: Add support for signed url downloads

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.33.0
+  rev: v1.39.0
   hooks:
     - id: terraform_fmt
     - id: terraform_docs

--- a/modules/s3_hosting/README.md
+++ b/modules/s3_hosting/README.md
@@ -23,6 +23,7 @@ Create an S3 bucket and Cloudfront distribution for holding frontend application
 |------|-------------|------|---------|:--------:|
 | buckets | S3 hosting buckets | `set(string)` | n/a | yes |
 | certificate\_arns | ARN of the certificate we created for the assets domain, keyed by domain | `map` | n/a | yes |
+| cf\_signed\_downloads | Enable Cloudfront signed URLs | `bool` | `false` | no |
 | environment | The environment (dev/staging/prod) | `any` | n/a | yes |
 | project | The name of the project, mostly for tagging | `any` | n/a | yes |
 | route53\_zone\_id | ID of the Route53 zone to create a record in | `string` | n/a | yes |

--- a/modules/s3_hosting/main.tf
+++ b/modules/s3_hosting/main.tf
@@ -94,6 +94,7 @@ resource "aws_cloudfront_distribution" "client_assets_distribution" {
     min_ttl                = 0
     default_ttl            = 86400
     max_ttl                = 31536000
+    trusted_signers        = var.cf_signed_downloads ? ["self"] : null
 
     forwarded_values {
       query_string = false

--- a/modules/s3_hosting/variables.tf
+++ b/modules/s3_hosting/variables.tf
@@ -20,3 +20,9 @@ variable "route53_zone_id" {
   description = "ID of the Route53 zone to create a record in"
   type        = string
 }
+
+variable "cf_signed_downloads" {
+  type        = bool
+  description = "Enable Cloudfront signed URLs"
+  default     = false
+}


### PR DESCRIPTION
## Description
Add support for signed url downloads

https://app.zenhub.com/workspaces/commit-zero-5da8decc7046a60001c6db44/issues/commitdev/zero/268

- New variable: cf_signed_downloads
- Set trusted_signers when cf_signed_downloads is true

### Checklist

- [X] Validation tests are passing
- [X] README.md has been updated after any changes to variables and outputs. See https://github.com/commitdev/terraform-aws-zero/#doc-generation
