### PR TITLE
Allow domain aliases for certificates and hosting

### DIFF
--- a/modules/certificate/README.md
+++ b/modules/certificate/README.md
@@ -22,7 +22,7 @@ Create and validate ACM certificates.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| alternative\_names | Alternative names to allow for this certificate | `list(string)` | n/a | yes |
+| alternative\_names | Alternative names to allow for this certificate | `list(string)` | `[]` | no |
 | domain\_name | Domain to create an ACM Cert for | `string` | n/a | yes |
 | region | The AWS region | `any` | n/a | yes |
 | zone\_name | Domains of the Route53 hosted zone | `string` | n/a | yes |
@@ -31,8 +31,8 @@ Create and validate ACM certificates.
 
 | Name | Description |
 |------|-------------|
-| certificate\_arns | The ARNs of the created certificates, keyed by domain name |
-| certificate\_validations | The ids of the certificate validations. Provided as a dependency so dependents can wait until the cert is actually valid |
+| certificate\_arn | The ARN of the created certificate |
+| certificate\_validation | The id of the certificate validation. Provided as a dependency so dependents can wait until the cert is actually valid |
 | route53\_zone\_id | Identifier of the Route53 Zone |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/certificate/README.md
+++ b/modules/certificate/README.md
@@ -22,7 +22,8 @@ Create and validate ACM certificates.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| domain\_names | Domains to create an ACM Cert for | `list(string)` | n/a | yes |
+| alternative\_names | Alternative names to allow for this certificate | `list(string)` | n/a | yes |
+| domain\_name | Domain to create an ACM Cert for | `string` | n/a | yes |
 | region | The AWS region | `any` | n/a | yes |
 | zone\_name | Domains of the Route53 hosted zone | `string` | n/a | yes |
 

--- a/modules/certificate/main.tf
+++ b/modules/certificate/main.tf
@@ -24,6 +24,10 @@ resource "aws_acm_certificate" "cert" {
 
   domain_name       = var.domain_names[count.index]
   validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 # Route53 record to validate the certificate

--- a/modules/certificate/main.tf
+++ b/modules/certificate/main.tf
@@ -10,8 +10,9 @@ data "aws_route53_zone" "public" {
 
 # Create an ACM cert for this domain
 resource "aws_acm_certificate" "cert" {
-  domain_name       = var.domain_name
-  validation_method = "DNS"
+  domain_name               = var.domain_name
+  validation_method         = "DNS"
+  subject_alternative_names = var.alternative_names
 
   lifecycle {
     create_before_destroy = true

--- a/modules/certificate/outputs.tf
+++ b/modules/certificate/outputs.tf
@@ -3,12 +3,12 @@ output "route53_zone_id" {
   value       = data.aws_route53_zone.public.zone_id
 }
 
-output "certificate_arns" {
-  description = "The ARNs of the created certificates, keyed by domain name"
-  value       = zipmap(aws_acm_certificate.cert[*].domain_name, aws_acm_certificate.cert[*].arn)
+output "certificate_arn" {
+  description = "The ARN of the created certificate"
+  value       = aws_acm_certificate.cert.arn
 }
 
-output "certificate_validations" {
-  description = "The ids of the certificate validations. Provided as a dependency so dependents can wait until the cert is actually valid"
-  value       = aws_acm_certificate_validation.cert[*].id
+output "certificate_validation" {
+  description = "The id of the certificate validation. Provided as a dependency so dependents can wait until the cert is actually valid"
+  value       = aws_acm_certificate_validation.cert.id
 }

--- a/modules/certificate/variables.tf
+++ b/modules/certificate/variables.tf
@@ -15,4 +15,5 @@ variable "domain_name" {
 variable "alternative_names" {
   description = "Alternative names to allow for this certificate"
   type        = list(string)
+  default     = []
 }

--- a/modules/certificate/variables.tf
+++ b/modules/certificate/variables.tf
@@ -7,7 +7,12 @@ variable "zone_name" {
   type        = string
 }
 
-variable "domain_names" {
-  description = "Domains to create an ACM Cert for"
+variable "domain_name" {
+  description = "Domain to create an ACM Cert for"
+  type        = string
+}
+
+variable "alternative_names" {
+  description = "Alternative names to allow for this certificate"
   type        = list(string)
 }

--- a/modules/s3_hosting/README.md
+++ b/modules/s3_hosting/README.md
@@ -21,10 +21,11 @@ Create an S3 bucket and Cloudfront distribution for holding frontend application
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| buckets | S3 hosting buckets | `set(string)` | n/a | yes |
-| certificate\_arns | ARN of the certificate we created for the assets domain, keyed by domain | `map` | n/a | yes |
+| aliases | Additional domains that this cloudfront distribution will serve traffic for | `list(string)` | n/a | yes |
+| certificate\_arn | ARN of the certificate to use for this cloudfront distribution | `string` | n/a | yes |
 | cf\_signed\_downloads | Enable Cloudfront signed URLs | `bool` | `false` | no |
-| environment | The environment (dev/staging/prod) | `any` | n/a | yes |
+| domain | Domain to host content for. This will be the name of the bucket | `string` | n/a | yes |
+| environment | The environment (dev/stage/prod) | `any` | n/a | yes |
 | project | The name of the project, mostly for tagging | `any` | n/a | yes |
 | route53\_zone\_id | ID of the Route53 zone to create a record in | `string` | n/a | yes |
 
@@ -32,6 +33,6 @@ Create an S3 bucket and Cloudfront distribution for holding frontend application
 
 | Name | Description |
 |------|-------------|
-| cloudfront\_distribution\_ids | Identifiers of the created cloudfront distributions |
+| cloudfront\_distribution\_id | Identifier of the created cloudfront distribution |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/s3_hosting/README.md
+++ b/modules/s3_hosting/README.md
@@ -23,6 +23,7 @@ Create an S3 bucket and Cloudfront distribution for holding frontend application
 |------|-------------|------|---------|:--------:|
 | aliases | Additional domains that this cloudfront distribution will serve traffic for | `list(string)` | n/a | yes |
 | certificate\_arn | ARN of the certificate to use for this cloudfront distribution | `string` | n/a | yes |
+| certificate\_validation | Id of the certificate validation record for the provided cert. Used to create a dependency so we don't use the cert before it is ready | `string` | n/a | yes |
 | cf\_signed\_downloads | Enable Cloudfront signed URLs | `bool` | `false` | no |
 | domain | Domain to host content for. This will be the name of the bucket | `string` | n/a | yes |
 | environment | The environment (dev/stage/prod) | `any` | n/a | yes |
@@ -33,6 +34,7 @@ Create an S3 bucket and Cloudfront distribution for holding frontend application
 
 | Name | Description |
 |------|-------------|
+| bucket\_arn | ARN of the created S3 bucket |
 | cloudfront\_distribution\_id | Identifier of the created cloudfront distribution |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/s3_hosting/main.tf
+++ b/modules/s3_hosting/main.tf
@@ -1,5 +1,5 @@
 locals {
-  assets_access_identity = "${var.project}-${var.environment}-client-assets"
+  assets_access_identity = "${var.project}-${var.environment}-client-assets-${var.domain}"
 
   allDomains = concat([var.domain], var.aliases)
 

--- a/modules/s3_hosting/main.tf
+++ b/modules/s3_hosting/main.tf
@@ -1,20 +1,30 @@
 locals {
   assets_access_identity = "${var.project}-${var.environment}-client-assets"
+
+  allDomains = concat([var.domain], var.aliases)
+
+  # Find buckets that are the domain apex. These need to have A ALIAS records.
+  rootDomains = [
+    for domain in local.allDomains :
+    domain if length(regexall("\\.", domain)) == 1
+  ]
+
+  # Find buckets that are subdomains. These can have CNAME records.
+  subDomains = [
+    for domain in local.allDomains :
+    domain if length(regexall("\\.", domain)) > 1
+  ]
 }
 
 resource "aws_s3_bucket" "client_assets" {
-  for_each = var.buckets
-
   // Our bucket's name is going to be the same as our site's domain name.
-  bucket = each.value
+  bucket = var.domain
   acl    = "private" // The contents will be available through cloudfront, they should not be accessible publicly
 }
 
 # Deny public access to this bucket
 resource "aws_s3_bucket_public_access_block" "client_assets" {
-  for_each = var.buckets
-
-  bucket                  = aws_s3_bucket.client_assets[each.value].id
+  bucket                  = aws_s3_bucket.client_assets.id
   block_public_acls       = true
   block_public_policy     = true
   ignore_public_acls      = true
@@ -28,11 +38,9 @@ resource "aws_cloudfront_origin_access_identity" "client_assets" {
 
 # Policy to allow CF access to S3
 data "aws_iam_policy_document" "assets_origin" {
-  for_each = var.buckets
-
   statement {
     actions   = ["s3:GetObject"]
-    resources = ["arn:aws:s3:::${aws_s3_bucket.client_assets[each.value].id}/*"]
+    resources = ["arn:aws:s3:::${aws_s3_bucket.client_assets.id}/*"]
 
     principals {
       type        = "AWS"
@@ -42,7 +50,7 @@ data "aws_iam_policy_document" "assets_origin" {
 
   statement {
     actions   = ["s3:ListBucket"]
-    resources = ["arn:aws:s3:::${aws_s3_bucket.client_assets[each.value].id}"]
+    resources = ["arn:aws:s3:::${aws_s3_bucket.client_assets.id}"]
 
     principals {
       type        = "AWS"
@@ -53,19 +61,15 @@ data "aws_iam_policy_document" "assets_origin" {
 
 # Attach the policy to the bucket
 resource "aws_s3_bucket_policy" "client_assets" {
-  for_each = var.buckets
-
-  bucket = aws_s3_bucket.client_assets[each.value].id
-  policy = data.aws_iam_policy_document.assets_origin[each.value].json
+  bucket = aws_s3_bucket.client_assets.id
+  policy = data.aws_iam_policy_document.assets_origin.json
 }
 
 # Create the cloudfront distribution
 resource "aws_cloudfront_distribution" "client_assets_distribution" {
-  for_each = var.buckets
-
   // origin is where CloudFront gets its content from.
   origin {
-    domain_name = aws_s3_bucket.client_assets[each.value].bucket_domain_name
+    domain_name = aws_s3_bucket.client_assets.bucket_domain_name
     origin_id   = local.assets_access_identity
     s3_origin_config {
       origin_access_identity = aws_cloudfront_origin_access_identity.client_assets.cloudfront_access_identity_path
@@ -105,7 +109,7 @@ resource "aws_cloudfront_distribution" "client_assets_distribution" {
   }
 
   aliases = [
-    each.value,
+    local.allDomains,
   ]
 
   restrictions {
@@ -116,49 +120,34 @@ resource "aws_cloudfront_distribution" "client_assets_distribution" {
 
   # Use our cert
   viewer_certificate {
-    acm_certificate_arn      = var.certificate_arns[each.value]
+    acm_certificate_arn      = var.certificate_arn
     minimum_protocol_version = "TLSv1"
     ssl_support_method       = "sni-only"
   }
 }
 
-locals {
-  # Find buckets that are the domain apex. These need to have A ALIAS records.
-  rootDomainBuckets = [
-    for bucket in var.buckets :
-    bucket if length(regexall("\\.", bucket)) == 1
-  ]
-
-  # Find buckets that are subdomains. These can have CNAME records.
-  subDomainBuckets = [
-    for bucket in var.buckets :
-    bucket if length(regexall("\\.", bucket)) > 1
-  ]
-
-}
-
 # Root domains to point at CF
 resource "aws_route53_record" "client_assets_root" {
-  count = length(local.rootDomainBuckets)
+  count = length(local.rootDomains)
 
   zone_id = var.route53_zone_id
-  name    = local.rootDomainBuckets[count.index]
+  name    = local.rootDomains[count.index]
   type    = "A"
 
   alias {
-    name                   = aws_cloudfront_distribution.client_assets_distribution[local.rootDomainBuckets[count.index]].domain_name
-    zone_id                = aws_cloudfront_distribution.client_assets_distribution[local.rootDomainBuckets[count.index]].hosted_zone_id
+    name                   = aws_cloudfront_distribution.client_assets_distribution.domain_name
+    zone_id                = aws_cloudfront_distribution.client_assets_distribution.hosted_zone_id
     evaluate_target_health = false
   }
 }
 
 # Subdomains to point at CF
 resource "aws_route53_record" "client_assets_subdomain" {
-  count = length(local.subDomainBuckets)
+  count = length(local.subDomains)
 
   zone_id = var.route53_zone_id
-  name    = local.subDomainBuckets[count.index]
+  name    = local.subDomains[count.index]
   type    = "CNAME"
   ttl     = "120"
-  records = [aws_cloudfront_distribution.client_assets_distribution[local.subDomainBuckets[count.index]].domain_name]
+  records = [aws_cloudfront_distribution.client_assets_distribution.domain_name]
 }

--- a/modules/s3_hosting/main.tf
+++ b/modules/s3_hosting/main.tf
@@ -108,9 +108,7 @@ resource "aws_cloudfront_distribution" "client_assets_distribution" {
     }
   }
 
-  aliases = [
-    local.allDomains,
-  ]
+  aliases = local.allDomains
 
   restrictions {
     geo_restriction {
@@ -124,6 +122,8 @@ resource "aws_cloudfront_distribution" "client_assets_distribution" {
     minimum_protocol_version = "TLSv1"
     ssl_support_method       = "sni-only"
   }
+
+  depends_on = [var.certificate_validation]
 }
 
 # Root domains to point at CF

--- a/modules/s3_hosting/outputs.tf
+++ b/modules/s3_hosting/outputs.tf
@@ -1,4 +1,4 @@
-output "cloudfront_distribution_ids" {
-  description = "Identifiers of the created cloudfront distributions"
-  value       = values(aws_cloudfront_distribution.client_assets_distribution)[*].id
+output "cloudfront_distribution_id" {
+  description = "Identifier of the created cloudfront distribution"
+  value       = aws_cloudfront_distribution.client_assets_distribution.id
 }

--- a/modules/s3_hosting/outputs.tf
+++ b/modules/s3_hosting/outputs.tf
@@ -2,3 +2,8 @@ output "cloudfront_distribution_id" {
   description = "Identifier of the created cloudfront distribution"
   value       = aws_cloudfront_distribution.client_assets_distribution.id
 }
+
+output "bucket_arn" {
+  description = "ARN of the created S3 bucket"
+  value       = aws_s3_bucket.client_assets.arn
+}

--- a/modules/s3_hosting/variables.tf
+++ b/modules/s3_hosting/variables.tf
@@ -21,6 +21,11 @@ variable "certificate_arn" {
   type        = string
 }
 
+variable "certificate_validation" {
+  description = "Id of the certificate validation record for the provided cert. Used to create a dependency so we don't use the cert before it is ready"
+  type        = string
+}
+
 variable "route53_zone_id" {
   description = "ID of the Route53 zone to create a record in"
   type        = string

--- a/modules/s3_hosting/variables.tf
+++ b/modules/s3_hosting/variables.tf
@@ -3,17 +3,22 @@ variable "project" {
 }
 
 variable "environment" {
-  description = "The environment (dev/staging/prod)"
+  description = "The environment (dev/stage/prod)"
 }
 
-variable "buckets" {
-  description = "S3 hosting buckets"
-  type        = set(string)
+variable "domain" {
+  description = "Domain to host content for. This will be the name of the bucket"
+  type        = string
 }
 
-variable "certificate_arns" {
-  description = "ARN of the certificate we created for the assets domain, keyed by domain"
-  type        = map
+variable "aliases" {
+  description = "Additional domains that this cloudfront distribution will serve traffic for"
+  type        = list(string)
+}
+
+variable "certificate_arn" {
+  description = "ARN of the certificate to use for this cloudfront distribution"
+  type        = string
 }
 
 variable "route53_zone_id" {


### PR DESCRIPTION
- enhancement: Allow adding SubjectAltNames for certificate
- Corrected outputs and defaults for certificate module
- enhancement: Allow adding domain aliases for s3 hosting module

## Description

Breaking change to both certificates and s3_hosting modules. They now accept only one domain each, and allow multiple domain aliases to be passed in.

(closes #7)

### Checklist

- [ ] Validation tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/commitdev/terraform-aws-zero/#doc-generation
