### PR TITLE
improvement: allow specifying cf-trusted signers

### DIFF
--- a/modules/s3_hosting/README.md
+++ b/modules/s3_hosting/README.md
@@ -25,6 +25,7 @@ Create an S3 bucket and Cloudfront distribution for holding frontend application
 | certificate\_arn | ARN of the certificate to use for this cloudfront distribution | `string` | n/a | yes |
 | certificate\_validation | Id of the certificate validation record for the provided cert. Used to create a dependency so we don't use the cert before it is ready | `string` | n/a | yes |
 | cf\_signed\_downloads | Enable Cloudfront signed URLs | `bool` | `false` | no |
+| cf\_trusted\_signers | Only available when cf\_signed\_downloads is enabled, a list of trusted signers(self/account\_id) for Cloudfront, used for signing URLs | `list(string)` | <pre>[<br>  "self"<br>]</pre> | no |
 | domain | Domain to host content for. This will be the name of the bucket | `string` | n/a | yes |
 | environment | The environment (dev/stage/prod) | `any` | n/a | yes |
 | project | The name of the project, mostly for tagging | `any` | n/a | yes |

--- a/modules/s3_hosting/main.tf
+++ b/modules/s3_hosting/main.tf
@@ -99,7 +99,7 @@ resource "aws_cloudfront_distribution" "client_assets_distribution" {
     min_ttl                = 0
     default_ttl            = 86400
     max_ttl                = 31536000
-    trusted_signers        = var.cf_signed_downloads ? ["self"] : null
+    trusted_signers        = var.cf_signed_downloads ? var.cf_trusted_signers : null
 
     forwarded_values {
       query_string = false

--- a/modules/s3_hosting/variables.tf
+++ b/modules/s3_hosting/variables.tf
@@ -36,3 +36,9 @@ variable "cf_signed_downloads" {
   description = "Enable Cloudfront signed URLs"
   default     = false
 }
+
+variable "cf_trusted_signers" {
+  type        = list(string)
+  description = "Only available when cf_signed_downloads is enabled, a list of trusted signers(self/account_id) for Cloudfront, used for signing URLs"
+  default     = ["self"]
+}


### PR DESCRIPTION
## Description

cloudfront trusted signers are picked up from AWS account's root user, and in some cases user may need to specify a different account's signer to use

### Checklist

- [ ] Validation tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/commitdev/terraform-aws-zero/#doc-generation
