### PR TITLE
breaking: Switch EKS module to using managed node groups instead of worker groups

### DIFF
--- a/modules/eks/README.md
+++ b/modules/eks/README.md
@@ -26,13 +26,14 @@ Create a Kubernetes cluster using EKS.
 | environment | The environment (stage/prod) | `any` | n/a | yes |
 | iam\_account\_id | Account ID of the current IAM user | `any` | n/a | yes |
 | iam\_role\_mapping | List of mappings of AWS Roles to Kubernetes Groups | <pre>list(object({<br>    iam_role_arn  = string<br>    k8s_role_name = string<br>    k8s_groups    = list(string)<br>  }))</pre> | n/a | yes |
-| private\_subnets | VPC subnets for the EKS cluster | `any` | n/a | yes |
+| private\_subnets | VPC subnets for the EKS cluster | `list(string)` | n/a | yes |
 | project | Name of the project | `any` | n/a | yes |
+| use\_spot\_instances | Enable use of spot instances instead of on-demand. This can provide significant cost savings and should be stable due to the use of the termination handler, but means that individuial nodes could be restarted at any time. May not be suitable for clusters with long-running workloads | `bool` | `false` | no |
 | vpc\_id | VPC ID for EKS cluster | `any` | n/a | yes |
-| worker\_ami | The (EKS-optimized) AMI for EKS worker instances | `any` | n/a | yes |
+| worker\_ami\_type | AMI type for the EKS worker instances. The default will be the normal image. Other possibilities are AL2\_x86\_64\_GPU for gpu instances or AL2\_ARM\_64 for ARM instances | `string` | `"AL2_x86_64"` | no |
 | worker\_asg\_max\_size | Maximum number of instances for the EKS ASG | `any` | n/a | yes |
 | worker\_asg\_min\_size | Minimum number of instances for the EKS ASG | `any` | n/a | yes |
-| worker\_instance\_type | Instance type for the EKS workers | `any` | n/a | yes |
+| worker\_instance\_types | Instance types to use for the EKS workers. When use\_spot\_instances is true you may provide multiple instance types and it will diversify across the cheapest pools | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -16,15 +16,28 @@ variable "cluster_version" {
 
 variable "private_subnets" {
   description = "VPC subnets for the EKS cluster"
-  # type        = list(string)
+  type        = list(string)
 }
 
 variable "vpc_id" {
   description = "VPC ID for EKS cluster"
 }
 
-variable "worker_instance_type" {
-  description = "Instance type for the EKS workers"
+variable "worker_instance_types" {
+  description = "Instance types to use for the EKS workers. When use_spot_instances is true you may provide multiple instance types and it will diversify across the cheapest pools"
+  type        = list(string)
+  default     = []
+}
+
+variable "worker_ami_type" {
+  description = "AMI type for the EKS worker instances. The default will be the normal image. Other possibilities are AL2_x86_64_GPU for gpu instances or AL2_ARM_64 for ARM instances"
+  type        = string
+  default     = "AL2_x86_64"
+}
+variable "use_spot_instances" {
+  description = "Enable use of spot instances instead of on-demand. This can provide significant cost savings and should be stable due to the use of the termination handler, but means that individuial nodes could be restarted at any time. May not be suitable for clusters with long-running workloads"
+  type        = bool
+  default     = false
 }
 
 variable "worker_asg_min_size" {
@@ -33,10 +46,6 @@ variable "worker_asg_min_size" {
 
 variable "worker_asg_max_size" {
   description = "Maximum number of instances for the EKS ASG"
-}
-
-variable "worker_ami" {
-  description = "The (EKS-optimized) AMI for EKS worker instances"
 }
 
 variable "iam_account_id" {

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -49,7 +49,7 @@ module "nat_instance" {
   source  = "int128/nat-instance/aws"
   version = "2.0.0"
 
-  name = "${var.project}-${var.environment}"
+  name = "${var.project}-${var.environment}-nat"
 
   vpc_id                      = module.vpc.vpc_id
   public_subnet               = module.vpc.public_subnets[0]


### PR DESCRIPTION
## Description

Use managed node groups instead of worker groups, as node groups have more k8s compatibility, support for spot instances, etc.
Bump the version of the eks module.

### Checklist

- [ ] Validation tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/commitdev/terraform-aws-zero/#doc-generation
