### PR TITLE
fix: Return the EKS primary security group now for us to use in other modules, also connect the primary and additional security groups (only used for migration, as the additional security group won't be used anymore)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: hashicorp/setup-terraform@v1
+      with:
+        terraform_version: 0.14.8 # Required as of Apr 15 2021 because of breaking changes in tf 0.15
 
     - name: Terraform fmt
       id: fmt

--- a/modules/eks/README.md
+++ b/modules/eks/README.md
@@ -42,6 +42,6 @@ Create a Kubernetes cluster using EKS.
 | cluster\_id | Identifier of the EKS cluster |
 | worker\_iam\_role\_arn | The ARN of the EKS worker IAM role |
 | worker\_iam\_role\_name | The name of the EKS worker IAM role |
-| worker\_security\_group\_id | The security group of the EKS workers |
+| worker\_security\_group\_id | The security group of the EKS cluster |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -59,6 +59,8 @@ module "eks" {
   cluster_iam_role_name = "k8s-${var.cluster_name}-cluster"
   workers_role_name     = "k8s-${var.cluster_name}-workers"
 
+  worker_create_cluster_primary_security_group_rules = true
+
   # Unfortunately fluentd doesn't yet support oidc auth so we need to grant it to the worker nodes
   workers_additional_policies = ["arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"]
 

--- a/modules/eks/outputs.tf
+++ b/modules/eks/outputs.tf
@@ -14,6 +14,6 @@ output "worker_iam_role_name" {
 }
 
 output "worker_security_group_id" {
-  description = "The security group of the EKS workers"
-  value       = module.eks.worker_security_group_id
+  description = "The security group of the EKS cluster"
+  value       = module.eks.cluster_primary_security_group_id
 }


### PR DESCRIPTION
## Description

Please explain the changes you made here and link to any relevant issues.

### Checklist

- [ ] Validation tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/commitdev/terraform-aws-zero/#doc-generation
