### PR TITLE
fix: auth endpoints targeting wrong svc name

### DIFF
--- a/modules/user_auth/files/oathkeeper-values.yml
+++ b/modules/user_auth/files/oathkeeper-values.yml
@@ -117,7 +117,7 @@ oathkeeper:
         enabled: true
 
         config:
-          check_session_url: http://kratos-public/sessions/whoami
+          # check_session_url: http://kratos-public/sessions/whoami #set by user_auth.tf
           preserve_path: true
           extra_from: "@this"
           subject_from: "identity.traits.email"

--- a/modules/user_auth/files/oathkeeper_kratos_proxy_rules.yaml.tpl
+++ b/modules/user_auth/files/oathkeeper_kratos_proxy_rules.yaml.tpl
@@ -5,11 +5,11 @@
 apiVersion: oathkeeper.ory.sh/v1alpha1
 kind: Rule
 metadata:
-  name: kratos-public
+  name: kratos-${name}-public
   namespace: user-auth
 spec:
   upstream:
-    url: http://kratos-public.user-auth
+    url: http://kratos-${name}-public.user-auth
     stripPath: ${public_selfserve_endpoint}
     preserveHost: true
   match:
@@ -35,11 +35,11 @@ spec:
 apiVersion: oathkeeper.ory.sh/v1alpha1
 kind: Rule
 metadata:
-  name: kratos-form-data
+  name: kratos-${name}-form-data
   namespace: user-auth
 spec:
   upstream:
-    url: http://kratos-admin.user-auth
+    url: http://kratos-${name}-admin.user-auth
     stripPath: ${admin_selfserve_endpoint}
     preserveHost: true
   match:

--- a/modules/user_auth/main.tf
+++ b/modules/user_auth/main.tf
@@ -138,16 +138,12 @@ resource "helm_release" "kratos" {
     name  = "kratos.config.selfservice.flows.error.ui_url"
     value = "https://${var.frontend_service_domain}/auth/errors"
   }
-
-  set {
-    name  = "kratos.config.selfservice.flows."
-    value = "https://${var.frontend_service_domain}/"
-  }
 }
 
 data "template_file" "oathkeeper_kratos_proxy_rules" {
   template = file("${path.module}/files/oathkeeper_kratos_proxy_rules.yaml.tpl")
   vars = {
+    name                      = var.name
     backend_service_domain    = var.backend_service_domain
     public_selfserve_endpoint = "/.ory/kratos/public"
     admin_selfserve_endpoint  = "/.ory/kratos"
@@ -180,6 +176,11 @@ resource "helm_release" "oathkeeper" {
   set {
     name  = "oathkeeper.config.mutators.id_token.config.issuer_url"
     value = "https://${var.backend_service_domain}"
+  }
+
+  set {
+    name  = "oathkeeper.config.cookie_session.config.check_session_url"
+    value = "http://kratos-${var.name}-public/sessions/whoami"
   }
 
   # Clean up and set the JWKS content. This will become a secret mounted into the pod


### PR DESCRIPTION
since auth components are created by name instead of hardcoded
svc name of kratos and oathkeeper also became dynamic, which was not
addressed but the original change

## Description

Please explain the changes you made here and link to any relevant issues.

### Checklist

- [ ] Validation tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/commitdev/terraform-aws-zero/#doc-generation
