### PR TITLE
feat: S3_hosting create CF but use existing bucket

### DIFF
--- a/modules/s3_hosting/README.md
+++ b/modules/s3_hosting/README.md
@@ -28,7 +28,7 @@ Create an S3 bucket and Cloudfront distribution for holding frontend application
 | cf\_lambda\_function\_associations | A config block that triggers a lambda function with specific actions (maximum 4) | <pre>list(object({<br>    event_type   = string<br>    lambda_arn   = string<br>    include_body = bool<br>  }))</pre> | `[]` | no |
 | cf\_signed\_downloads | Enable Cloudfront signed URLs | `bool` | `false` | no |
 | cf\_trusted\_signers | Only available when cf\_signed\_downloads is enabled, a list of trusted signers(self/account\_id) for Cloudfront, used for signing URLs | `list(string)` | <pre>[<br>  "self"<br>]</pre> | no |
-| create\_s3\_bucket\_policy | Useful when multiple CF using the same bucket, then you may want to create the S3 Bucket policy manually to allow mulltiple principals | `bool` | `true` | no |
+| create\_s3\_bucket\_policy | Useful when multiple CF distributions access the same bucket. You would need to create a bucket policy that allows access from multiple distributions | `bool` | `true` | no |
 | domain | Domain to host content for. This will be the name of the bucket | `string` | n/a | yes |
 | environment | The environment (stage/prod) | `any` | n/a | yes |
 | project | The name of the project, mostly for tagging | `any` | n/a | yes |
@@ -40,7 +40,7 @@ Create an S3 bucket and Cloudfront distribution for holding frontend application
 | Name | Description |
 |------|-------------|
 | bucket\_arn | ARN of the created S3 bucket |
-| cf\_origin\_assets\_access\_identity\_arn | Cloudfront origin assets access identity, useful when multiple CF using the same bucket to manage S3 bucket policies. |
+| cf\_origin\_assets\_access\_identity\_arn | Cloudfront origin assets access identity, useful when multiple CF using the same bucket to manage S3 bucket policies |
 | cf\_signing\_enabled | Does this require signed URL downloads? |
 | cloudfront\_distribution\_id | Identifier of the created cloudfront distribution |
 

--- a/modules/s3_hosting/README.md
+++ b/modules/s3_hosting/README.md
@@ -28,16 +28,19 @@ Create an S3 bucket and Cloudfront distribution for holding frontend application
 | cf\_lambda\_function\_associations | A config block that triggers a lambda function with specific actions (maximum 4) | <pre>list(object({<br>    event_type   = string<br>    lambda_arn   = string<br>    include_body = bool<br>  }))</pre> | `[]` | no |
 | cf\_signed\_downloads | Enable Cloudfront signed URLs | `bool` | `false` | no |
 | cf\_trusted\_signers | Only available when cf\_signed\_downloads is enabled, a list of trusted signers(self/account\_id) for Cloudfront, used for signing URLs | `list(string)` | <pre>[<br>  "self"<br>]</pre> | no |
+| create\_s3\_bucket\_policy | Useful when multiple CF using the same bucket, then you may want to create the S3 Bucket policy manually to allow mulltiple principals | `bool` | `true` | no |
 | domain | Domain to host content for. This will be the name of the bucket | `string` | n/a | yes |
 | environment | The environment (stage/prod) | `any` | n/a | yes |
 | project | The name of the project, mostly for tagging | `any` | n/a | yes |
 | route53\_zone\_id | ID of the Route53 zone to create a record in | `string` | n/a | yes |
+| use\_existing\_s3\_bucket | Name of existing s3 Bucket to use instead of creating a new one | `string` | `""` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | bucket\_arn | ARN of the created S3 bucket |
+| cf\_origin\_assets\_access\_identity\_arn | Cloudfront origin assets access identity, useful when multiple CF using the same bucket to manage S3 bucket policies. |
 | cf\_signing\_enabled | Does this require signed URL downloads? |
 | cloudfront\_distribution\_id | Identifier of the created cloudfront distribution |
 

--- a/modules/s3_hosting/main.tf
+++ b/modules/s3_hosting/main.tf
@@ -21,9 +21,12 @@ locals {
     allowed_origins = var.allowed_cors_origins,
     max_age_seconds = 3000
   }] : []
+
+  createS3Bucket = var.use_existing_s3_bucket == "" ? true : false
 }
 
 resource "aws_s3_bucket" "client_assets" {
+  count = local.createS3Bucket ? 1 : 0
   // Our bucket's name is going to be the same as our site's domain name.
   bucket = var.domain
   acl    = "private" // The contents will be available through cloudfront, they should not be accessible publicly
@@ -48,14 +51,22 @@ resource "aws_s3_bucket" "client_assets" {
   }
 }
 
+// Use reference of the s3_bucket so the reference can be the same for both scenario
+// whether S3 bucket is existing or created from this module
+data "aws_s3_bucket" "client_assets" {
+  bucket = local.createS3Bucket ? aws_s3_bucket.client_assets[0].id : var.use_existing_s3_bucket
+}
+
 # Deny public access to this bucket
 resource "aws_s3_bucket_public_access_block" "client_assets" {
-  bucket                  = aws_s3_bucket.client_assets.id
+  count                   = local.createS3Bucket ? 1 : 0
+  bucket                  = aws_s3_bucket.client_assets[0].id
   block_public_acls       = true
   block_public_policy     = true
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
+
 
 # Access identity for CF access to S3
 resource "aws_cloudfront_origin_access_identity" "client_assets" {
@@ -64,9 +75,10 @@ resource "aws_cloudfront_origin_access_identity" "client_assets" {
 
 # Policy to allow CF access to S3
 data "aws_iam_policy_document" "assets_origin" {
+  count = var.create_s3_bucket_policy ? 1 : 0
   statement {
     actions   = ["s3:GetObject"]
-    resources = ["arn:aws:s3:::${aws_s3_bucket.client_assets.id}/*"]
+    resources = ["arn:aws:s3:::${data.aws_s3_bucket.client_assets.id}/*"]
 
     principals {
       type        = "AWS"
@@ -76,7 +88,7 @@ data "aws_iam_policy_document" "assets_origin" {
 
   statement {
     actions   = ["s3:ListBucket"]
-    resources = ["arn:aws:s3:::${aws_s3_bucket.client_assets.id}"]
+    resources = ["arn:aws:s3:::${data.aws_s3_bucket.client_assets.id}"]
 
     principals {
       type        = "AWS"
@@ -87,16 +99,17 @@ data "aws_iam_policy_document" "assets_origin" {
 
 # Attach the policy to the bucket
 resource "aws_s3_bucket_policy" "client_assets" {
+  count      = var.create_s3_bucket_policy ? 1 : 0
   depends_on = [aws_cloudfront_distribution.client_assets_distribution]
-  bucket     = aws_s3_bucket.client_assets.id
-  policy     = data.aws_iam_policy_document.assets_origin.json
+  bucket     = data.aws_s3_bucket.client_assets.id
+  policy     = data.aws_iam_policy_document.assets_origin[0].json
 }
 
 # Create the cloudfront distribution
 resource "aws_cloudfront_distribution" "client_assets_distribution" {
   // origin is where CloudFront gets its content from.
   origin {
-    domain_name = aws_s3_bucket.client_assets.bucket_domain_name
+    domain_name = data.aws_s3_bucket.client_assets.bucket_domain_name
     origin_id   = local.assets_access_identity
     s3_origin_config {
       origin_access_identity = aws_cloudfront_origin_access_identity.client_assets.cloudfront_access_identity_path

--- a/modules/s3_hosting/outputs.tf
+++ b/modules/s3_hosting/outputs.tf
@@ -5,10 +5,15 @@ output "cloudfront_distribution_id" {
 
 output "bucket_arn" {
   description = "ARN of the created S3 bucket"
-  value       = aws_s3_bucket.client_assets.arn
+  value       = data.aws_s3_bucket.client_assets.arn
 }
 
 output "cf_signing_enabled" {
   description = "Does this require signed URL downloads?"
   value       = var.cf_signed_downloads
+}
+
+output "cf_origin_assets_access_identity_arn" {
+  description = "Cloudfront origin assets access identity, useful when multiple CF using the same bucket to manage S3 bucket policies"
+  value       = aws_cloudfront_origin_access_identity.client_assets.iam_arn
 }

--- a/modules/s3_hosting/variables.tf
+++ b/modules/s3_hosting/variables.tf
@@ -18,7 +18,7 @@ variable "use_existing_s3_bucket" {
 }
 
 variable "create_s3_bucket_policy" {
-  description = "Useful when multiple CF using the same bucket, then you may want to create the S3 Bucket policy manually to allow mulltiple principals"
+  description = "Useful when multiple CF distributions access the same bucket. You would need to create a bucket policy that allows access from multiple distributions"
   type        = bool
   default     = true
 }

--- a/modules/s3_hosting/variables.tf
+++ b/modules/s3_hosting/variables.tf
@@ -11,6 +11,19 @@ variable "domain" {
   type        = string
 }
 
+variable "use_existing_s3_bucket" {
+  description = "Name of existing s3 Bucket to use instead of creating a new one"
+  type        = string
+  default     = ""
+}
+
+variable "create_s3_bucket_policy" {
+  description = "Useful when multiple CF using the same bucket, then you may want to create the S3 Bucket policy manually to allow mulltiple principals"
+  type        = bool
+  default     = true
+}
+
+
 variable "aliases" {
   description = "Additional domains that this cloudfront distribution will serve traffic for"
   type        = list(string)


### PR DESCRIPTION
this is useful for multiple CF pointing to one bucket,
user can manually create the s3 bucket policy allowing both CF to view
using their assets acess identity

## Description

Please explain the changes you made here and link to any relevant issues.

### Checklist

- [ ] Validation tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/commitdev/terraform-aws-zero/#doc-generation
