### PR TITLE
enhancement: user_access module now supports passing in aws account ids to set up trust policies so users in different accounts can assume the roles we create

### DIFF
--- a/modules/user_access/README.md
+++ b/modules/user_access/README.md
@@ -22,10 +22,11 @@ Create IAM Roles/Groups and Kubernetes Cluster Roles for user access
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| assumerole\_account\_ids | AWS account IDs that will be allowed to assume the roles we are creating. If left blank, the AWS account you are using will be used | `list(string)` | `[]` | no |
 | environment | The environment (stage/prod) | `any` | n/a | yes |
 | project | Name of the project | `any` | n/a | yes |
-| roles | Role list with policies | <pre>list(object({<br>    name         = string<br>    aws_policy   = string<br>    k8s_policies = list(map(list(string)))<br>  }))</pre> | n/a | yes |
-| users | User list with roles | <pre>list(object({<br>    name  = string<br>    roles = list(string)<br>  }))</pre> | n/a | yes |
+| roles | Roles to create with associated aws and k8s policies | <pre>list(object({<br>    name         = string<br>    aws_policy   = string<br>    k8s_policies = list(map(list(string)))<br>  }))</pre> | n/a | yes |
+| users | Users to create with associated roles, mapping to the ones defined in the roles variable | <pre>list(object({<br>    name  = string<br>    roles = list(string)<br>  }))</pre> | n/a | yes |
 
 ## Outputs
 

--- a/modules/user_access/main.tf
+++ b/modules/user_access/main.tf
@@ -79,7 +79,7 @@ data "aws_iam_policy_document" "access_assumerole_root_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = [local.account_id]
+      identifiers = var.assumerole_account_ids == [] ? [local.account_id] : var.assumerole_account_ids
     }
   }
 }

--- a/modules/user_access/variables.tf
+++ b/modules/user_access/variables.tf
@@ -7,18 +7,24 @@ variable "environment" {
 }
 
 variable "roles" {
+  description = "Roles to create with associated aws and k8s policies"
   type = list(object({
     name         = string
     aws_policy   = string
     k8s_policies = list(map(list(string)))
   }))
-  description = "Role list with policies"
 }
 
 variable "users" {
+  description = "Users to create with associated roles, mapping to the ones defined in the roles variable"
   type = list(object({
     name  = string
     roles = list(string)
   }))
-  description = "User list with roles"
+}
+
+variable "assumerole_account_ids" {
+  description = "AWS account IDs that will be allowed to assume the roles we are creating. If left blank, the AWS account you are using will be used"
+  type        = list(string)
+  default     = []
 }


### PR DESCRIPTION
## Description

Please explain the changes you made here and link to any relevant issues.

### Checklist

- [ ] Validation tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/commitdev/terraform-aws-zero/#doc-generation
