### PR TITLE
enhancement: Added support for EKS prefix delegation, allowing nodes to have many more IPs (17 -> 110), also change how the eks module accepts node group parameters.

### DIFF
--- a/modules/eks/README.md
+++ b/modules/eks/README.md
@@ -17,7 +17,7 @@ See the necessary versions for each EKS version here:
 *Node group configuration schema:*
 ```
 {
-    node_name: {
+    <group name>: {
         instance_types     = list(string) - List of instance types to use for nodes in the node group. In order of preference. Instance types in a group should be similar in resources.
         asg_min_size       = string (default: "1") - Smallest size of this node group in instances.
         asg_max_size       = string (default: "3") - Largest size of this node group in instances.
@@ -25,6 +25,8 @@ See the necessary versions for each EKS version here:
         ami_type           = string (default: "AL2_x86_64") - The type of AMI to use. Other possibilities are AL2_x86_64_GPU for gpu instances or AL2_ARM_64 for ARM instances
         use_large_ip_range = bool (default: true) - If true, enable the "prefix delegation" feature of EKS. This will create a custom launch template for each node group.
         node_ip_limit      = int  (default: 110)  - If using prefix delegation, the max that can be used per node. 110 is the limit for all but the largest instance types.
+    },
+    ...
 }
 ```
 

--- a/modules/eks/README.md
+++ b/modules/eks/README.md
@@ -14,6 +14,20 @@ See the necessary versions for each EKS version here:
 
 [https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html](https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html)
 
+*Node group configuration schema:*
+```
+{
+    node_name: {
+        instance_types     = list(string) - List of instance types to use for nodes in the node group. In order of preference. Instance types in a group should be similar in resources.
+        asg_min_size       = string (default: "1") - Smallest size of this node group in instances.
+        asg_max_size       = string (default: "3") - Largest size of this node group in instances.
+        use_spot_instances = bool (default: false) - If true, use spot instances to save cost.
+        ami_type           = string (default: "AL2_x86_64") - The type of AMI to use. Other possibilities are AL2_x86_64_GPU for gpu instances or AL2_ARM_64 for ARM instances
+        use_large_ip_range = bool (default: true) - If true, enable the "prefix delegation" feature of EKS. This will create a custom launch template for each node group.
+        node_ip_limit      = int  (default: 110)  - If using prefix delegation, the max that can be used per node. 110 is the limit for all but the largest instance types.
+}
+```
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
@@ -27,6 +41,7 @@ See the necessary versions for each EKS version here:
 | Name | Version |
 |------|---------|
 | aws | >= 3.37.0 |
+| null | n/a |
 
 ## Inputs
 
@@ -37,7 +52,7 @@ See the necessary versions for each EKS version here:
 | addon\_vpc\_cni\_version | Version of the VPC CNI to install. If empty you will need to upgrade the CNI yourself during a cluster version upgrade | `string` | `""` | no |
 | cluster\_name | Name to be given to the EKS cluster | `any` | n/a | yes |
 | cluster\_version | EKS cluster version number to use. Incrementing this will start a cluster upgrade | `any` | n/a | yes |
-| eks\_node\_groups | Map of maps of EKS node group config where keys are node group names | <pre>map(object({<br>    instance_types     = list(string)<br>    asg_min_size       = string<br>    asg_max_size       = string<br>    use_spot_instances = bool<br>    ami_type           = string<br>  }))</pre> | n/a | yes |
+| eks\_node\_groups | Map of maps of EKS node group config where keys are node group names. See the readme for details. | `any` | n/a | yes |
 | environment | The environment (stage/prod) | `any` | n/a | yes |
 | iam\_account\_id | Account ID of the current IAM user | `any` | n/a | yes |
 | iam\_role\_mapping | List of mappings of AWS Roles to Kubernetes Groups | <pre>list(object({<br>    iam_role_arn  = string<br>    k8s_role_name = string<br>    k8s_groups    = list(string)<br>  }))</pre> | n/a | yes |
@@ -52,6 +67,6 @@ See the necessary versions for each EKS version here:
 | cluster\_id | Identifier of the EKS cluster |
 | worker\_iam\_role\_arn | The ARN of the EKS worker IAM role |
 | worker\_iam\_role\_name | The name of the EKS worker IAM role |
-| worker\_security\_group\_id | The security group of the EKS cluster |
+| worker\_security\_group\_id | The security group of the EKS workers |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/eks/outputs.tf
+++ b/modules/eks/outputs.tf
@@ -14,6 +14,6 @@ output "worker_iam_role_name" {
 }
 
 output "worker_security_group_id" {
-  description = "The security group of the EKS cluster"
-  value       = module.eks.cluster_primary_security_group_id
+  description = "The security group of the EKS workers"
+  value       = module.eks.worker_security_group_id
 }

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -24,14 +24,8 @@ variable "vpc_id" {
 }
 
 variable "eks_node_groups" {
-  type = map(object({
-    instance_types     = list(string)
-    asg_min_size       = string
-    asg_max_size       = string
-    use_spot_instances = bool
-    ami_type           = string
-  }))
-  description = "Map of maps of EKS node group config where keys are node group names"
+  type        = any
+  description = "Map of maps of EKS node group config where keys are node group names. See the readme for details."
 }
 
 variable "iam_account_id" {


### PR DESCRIPTION
breaking change: Switched back to using the worker security group instead of the "cluster primary" security group - we were only using it because we weren't creating a custom launch template and with this change we will be. If you are trying to upgrade, this map require tmeporarily adding a security group rule to allow your old node groups to access the db, bringing up new node groups with the new configuration, then removing your old node groups.

## Description

Please explain the changes you made here and link to any relevant issues.

### Checklist

- [ ] Validation tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/commitdev/terraform-aws-zero/#doc-generation
