### PR TITLE
fix: Compatibility fix as a band-aid for cases where someone created their cluster before this module made a change to the cluster role name

### DIFF
--- a/modules/eks/README.md
+++ b/modules/eks/README.md
@@ -29,6 +29,7 @@ See the necessary versions for each EKS version here:
     ...
 }
 ```
+Note: To fully enable prefix delegation, the ENABLE_PREFIX_DELEGATION environment variable must be set to "true" in the aws-node daemonset. Zero will do this automatically when the kubernetes terraform is applied.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
@@ -43,7 +44,6 @@ See the necessary versions for each EKS version here:
 | Name | Version |
 |------|---------|
 | aws | >= 3.37.0 |
-| null | n/a |
 
 ## Inputs
 

--- a/modules/eks/README.md
+++ b/modules/eks/README.md
@@ -56,6 +56,7 @@ See the necessary versions for each EKS version here:
 | cluster\_version | EKS cluster version number to use. Incrementing this will start a cluster upgrade | `any` | n/a | yes |
 | eks\_node\_groups | Map of maps of EKS node group config where keys are node group names. See the readme for details. | `any` | n/a | yes |
 | environment | The environment (stage/prod) | `any` | n/a | yes |
+| force\_old\_cluster\_iam\_role\_name | Compatibility fix - If your cluster was created using a version of this module earlier than 0.4.3, this should be set to true. If the wrong value is set, you may see kubernetes connection issues when running terraform | `bool` | `false` | no |
 | iam\_account\_id | Account ID of the current IAM user | `any` | n/a | yes |
 | iam\_role\_mapping | List of mappings of AWS Roles to Kubernetes Groups | <pre>list(object({<br>    iam_role_arn  = string<br>    k8s_role_name = string<br>    k8s_groups    = list(string)<br>  }))</pre> | n/a | yes |
 | private\_subnets | VPC subnets for the EKS cluster | `list(string)` | n/a | yes |

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -69,7 +69,11 @@ module "eks" {
     ]
   )
 
-  workers_role_name = "k8s-${var.cluster_name}-workers"
+  # Compatibility fix - if this value changes on a running cluster there is a super obscure error message when running terraform plan:
+  # Error: Get "http://localhost/apis/rbac.authorization.k8s.io/v1/clusterroles/helix-kubernetes-developer-stage": dial tcp [::1]:80: connect: connection refused
+  # We can leave this option here to allow people to upgrade
+  cluster_iam_role_name = var.force_old_cluster_iam_role_name ? "k8s-${var.cluster_name}-cluster" : ""
+  workers_role_name     = "k8s-${var.cluster_name}-workers"
 
   worker_create_cluster_primary_security_group_rules = true
 

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -113,19 +113,3 @@ resource "aws_eks_addon" "coredns" {
   resolve_conflicts = "OVERWRITE"
   addon_version     = var.addon_coredns_version
 }
-
-# Enable prefix delegation - this will enable many more IPs to be allocated per-node.
-# See https://docs.aws.amazon.com/eks/latest/userguide/cni-increase-ip-addresses.html
-resource "null_resource" "enable_prefix_delegation" {
-  count = var.addon_vpc_cni_version == "" ? 0 : 1
-
-  triggers = {
-    manifest_sha1 = sha1(var.addon_vpc_cni_version)
-  }
-
-  provisioner "local-exec" {
-    command = "kubectl set env daemonset aws-node ${local.k8s_exec_context} -n kube-system ENABLE_PREFIX_DELEGATION=true WARM_PREFIX_TARGET=1"
-  }
-
-  depends_on = [aws_eks_addon.vpc_cni]
-}

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -58,3 +58,9 @@ variable "addon_coredns_version" {
   type        = string
   default     = ""
 }
+
+variable "force_old_cluster_iam_role_name" {
+  description = "Compatibility fix - If your cluster was created using a version of this module earlier than 0.4.3, this should be set to true. If the wrong value is set, you may see kubernetes connection issues when running terraform"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Description

There was a change introduced in 0.4.3 of this module that stopped specifying the cluster role name, presumably to fix this same issue with clusters created at some point in the past.
The problem we see is that if you create a cluster, and then try to change this role name, `terraform plan` will not even succeed, instead you get obscure error messages like this:

```
Error: Get "http://localhost/api/v1/namespaces/kube-system/configmaps/aws-auth": dial tcp [::1]:80: connect: connection refused
```

This change will let older cluster operators upgrade to newer versions of this module while still maintaining the old cluster role name.

### Checklist

- [ ] Validation tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/commitdev/terraform-aws-zero/#doc-generation
