### PR TITLE
fix: typo in user_auth oathkeeper config

### DIFF
--- a/modules/user_auth/main.tf
+++ b/modules/user_auth/main.tf
@@ -109,7 +109,7 @@ locals {
         }
       }
     }
-    oathkeeer = {
+    oathkeeper = {
       config = {
         authenticators = {
           cookie_session = {


### PR DESCRIPTION
## Description

Please explain the changes you made here and link to any relevant issues.

### Checklist

- [ ] Validation tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/commitdev/terraform-aws-zero/#doc-generation
