### PR TITLE
improvement: support user-auth local dev kratos

### DIFF
--- a/modules/user_auth/README.md
+++ b/modules/user_auth/README.md
@@ -35,6 +35,8 @@ No requirements.
 | backend\_service\_domain | Domain of the backend service | `string` | n/a | yes |
 | cookie\_signing\_secret\_key | Default secret key for signing cookies | `string` | n/a | yes |
 | create\_namespace | Whether to create the auth namespace(defaults to true), otherwise just references the namespace | `bool` | `true` | no |
+| disable\_frontend\_https | Whether frontend URLs should be https, unless your developing locally you should leave the default as is. | `bool` | `false` | no |
+| disable\_oathkeeper | To not provision Oathkeeper, this is useful when you want multiple Kratos setup, while only 1 Oathkeeper proxy to route to them, for example sharing Oathkeeper between a Dev and Staging Kratos | `bool` | `false` | no |
 | external\_secret\_backend | The backend external-secrets will pull secret data from to create a corresponding secret in kubernetes. If empty, external-secrets will not be used. You'll need to make sure the secret is created manually. | `string` | `"secretsManager"` | no |
 | external\_secret\_name | Name of a secret in an external secrets backend that contains the content to pull into a kubernetes secret for Kratos to use | `string` | n/a | yes |
 | frontend\_service\_domain | Domain of the frontend | `string` | n/a | yes |

--- a/modules/user_auth/README.md
+++ b/modules/user_auth/README.md
@@ -35,11 +35,11 @@ No requirements.
 | backend\_service\_domain | Domain of the backend service | `string` | n/a | yes |
 | cookie\_signing\_secret\_key | Default secret key for signing cookies | `string` | n/a | yes |
 | create\_namespace | Whether to create the auth namespace(defaults to true), otherwise just references the namespace | `bool` | `true` | no |
-| disable\_frontend\_https | Whether frontend URLs should be https, unless your developing locally you should leave the default as is. | `bool` | `false` | no |
 | disable\_oathkeeper | To not provision Oathkeeper, this is useful when you want multiple Kratos setup, while only 1 Oathkeeper proxy to route to them, for example sharing Oathkeeper between a Dev and Staging Kratos | `bool` | `false` | no |
 | external\_secret\_backend | The backend external-secrets will pull secret data from to create a corresponding secret in kubernetes. If empty, external-secrets will not be used. You'll need to make sure the secret is created manually. | `string` | `"secretsManager"` | no |
 | external\_secret\_name | Name of a secret in an external secrets backend that contains the content to pull into a kubernetes secret for Kratos to use | `string` | n/a | yes |
 | frontend\_service\_domain | Domain of the frontend | `string` | n/a | yes |
+| frontend\_use\_https | Whether frontend URLs should be https, unless your developing locally you should leave the default as is. | `bool` | `true` | no |
 | jwks\_content | The content of a JWKS file for Oathkeeper | `string` | n/a | yes |
 | k8s\_local\_exec\_context | Custom resource (Oathkeeper Rules are created using local-exec with kubectl), if not specified it will target your current context from kubeconfig | `string` | `""` | no |
 | kratos\_default\_redirect\_ui\_path | Setting the default path after self-service flows(login/signup/verify/settings), kratos will redirect you to frontend | `string` | `"/dashboard"` | no |

--- a/modules/user_auth/files/oathkeeper_kratos_proxy_rules.yaml.tpl
+++ b/modules/user_auth/files/oathkeeper_kratos_proxy_rules.yaml.tpl
@@ -6,10 +6,10 @@ apiVersion: oathkeeper.ory.sh/v1alpha1
 kind: Rule
 metadata:
   name: kratos-${name}-public
-  namespace: user-auth
+  namespace: ${auth_namespace}
 spec:
   upstream:
-    url: http://kratos-${name}-public.user-auth
+    url: http://kratos-${name}-public.${auth_namespace}
     stripPath: ${public_selfserve_endpoint}
     preserveHost: true
   match:
@@ -36,10 +36,10 @@ apiVersion: oathkeeper.ory.sh/v1alpha1
 kind: Rule
 metadata:
   name: kratos-${name}-form-data
-  namespace: user-auth
+  namespace: ${auth_namespace}
 spec:
   upstream:
-    url: http://kratos-${name}-admin.user-auth
+    url: http://kratos-${name}-admin.${auth_namespace}
     stripPath: ${admin_selfserve_endpoint}
     preserveHost: true
   match:

--- a/modules/user_auth/main.tf
+++ b/modules/user_auth/main.tf
@@ -14,7 +14,7 @@ locals {
     }
   }
 
-  frontend_scheme         = var.disable_frontend_https ? "http" : "https"
+  frontend_scheme         = var.frontend_use_https ? "https" : "http"
   default_flow_return_url = "${local.frontend_scheme}://${var.frontend_service_domain}${var.kratos_default_redirect_ui_path}"
   kratos_values_override = {
     secret = {

--- a/modules/user_auth/main.tf
+++ b/modules/user_auth/main.tf
@@ -14,7 +14,8 @@ locals {
     }
   }
 
-  default_flow_return_url = "https://${var.frontend_service_domain}${var.kratos_default_redirect_ui_path}"
+  frontend_scheme         = var.disable_frontend_https ? "http" : "https"
+  default_flow_return_url = "${local.frontend_scheme}://${var.frontend_service_domain}${var.kratos_default_redirect_ui_path}"
   kratos_values_override = {
     secret = {
       nameOverride = var.kratos_secret_name
@@ -32,38 +33,38 @@ locals {
 
         selfservice = {
           whitelisted_return_urls    = var.whitelisted_return_urls
-          default_browser_return_url = "https://${var.frontend_service_domain}/"
+          default_browser_return_url = "${local.frontend_scheme}://${var.frontend_service_domain}/"
           flows = {
             settings = {
-              ui_url = "https://${var.frontend_service_domain}/auth/settings"
+              ui_url = "${local.frontend_scheme}://${var.frontend_service_domain}/auth/settings"
               after = {
                 default_browser_return_url = local.default_flow_return_url
               }
             }
 
             verification = {
-              ui_url = "https://${var.frontend_service_domain}/auth/verify"
+              ui_url = "${local.frontend_scheme}://${var.frontend_service_domain}/auth/verify"
               after = {
                 default_browser_return_url = local.default_flow_return_url
               }
             }
 
             recovery = {
-              ui_url = "https://${var.frontend_service_domain}/auth/recovery"
+              ui_url = "${local.frontend_scheme}://${var.frontend_service_domain}/auth/recovery"
               after = {
                 default_browser_return_url = local.default_flow_return_url
               }
             }
 
             login = {
-              ui_url = "https://${var.frontend_service_domain}/auth/login"
+              ui_url = "${local.frontend_scheme}://${var.frontend_service_domain}/auth/login"
               after = {
                 default_browser_return_url = local.default_flow_return_url
               }
             }
 
             registration = {
-              ui_url = "https://${var.frontend_service_domain}/auth/registration"
+              ui_url = "${local.frontend_scheme}://${var.frontend_service_domain}/auth/registration"
               after = {
                 default_browser_return_url = local.default_flow_return_url
                 password = {
@@ -76,7 +77,7 @@ locals {
             }
 
             error = {
-              ui_url = "https://${var.frontend_service_domain}/auth/errors"
+              ui_url = "${local.frontend_scheme}://${var.frontend_service_domain}/auth/errors"
             }
 
           }
@@ -95,17 +96,17 @@ locals {
       # https://github.com/ory/k8s/blob/master/helm/charts/oathkeeper/templates/ingress-proxy.yaml
       proxy = {
         hosts = [{
-          host = var.backend_service_domain
+          host  = var.backend_service_domain
           paths = ["/"]
         }]
 
         tls = [{
-          hosts = [var.backend_service_domain]
+          hosts      = [var.backend_service_domain]
           secretName = "oathkeeper-proxy-tls-secret"
         }]
 
         annotations = {
-          "nginx.ingress.kubernetes.io/cors-allow-origin" : "https://${var.frontend_service_domain}"
+          "nginx.ingress.kubernetes.io/cors-allow-origin" : "${local.frontend_scheme}://${var.frontend_service_domain}"
         }
       }
     }
@@ -131,7 +132,7 @@ locals {
           handlers = {
             redirect = {
               config = {
-                to = "https://${var.frontend_service_domain}/auth/login"
+                to = "${local.frontend_scheme}://${var.frontend_service_domain}/auth/login"
               }
             }
           }
@@ -205,6 +206,7 @@ data "template_file" "oathkeeper_kratos_proxy_rules" {
     backend_service_domain    = var.backend_service_domain
     public_selfserve_endpoint = "/.ory/kratos/public"
     admin_selfserve_endpoint  = "/.ory/kratos"
+    auth_namespace            = var.auth_namespace
   }
 }
 
@@ -220,6 +222,8 @@ resource "null_resource" "oathkeeper_kratos_proxy_rules" {
 }
 
 module "oathkeeper_config" {
+  count = var.disable_oathkeeper ? 0 : 1
+
   source  = "cloudposse/config/yaml"
   version = "0.7.0"
 
@@ -229,6 +233,7 @@ module "oathkeeper_config" {
 }
 
 resource "helm_release" "oathkeeper" {
+  count = var.disable_oathkeeper ? 0 : 1
 
   name       = "oathkeeper-${var.name}"
   repository = "https://k8s.ory.sh/helm/charts"
@@ -238,7 +243,7 @@ resource "helm_release" "oathkeeper" {
   depends_on = [kubernetes_namespace.user_auth]
 
   values = [
-    jsonencode(module.oathkeeper_config.map_configs)
+    jsonencode(module.oathkeeper_config[0].map_configs)
   ]
 
   # Clean up and set the JWKS content. This will become a secret mounted into the pod

--- a/modules/user_auth/variables.tf
+++ b/modules/user_auth/variables.tf
@@ -93,3 +93,15 @@ variable "kratos_default_redirect_ui_path" {
   type        = string
   default     = "/dashboard"
 }
+
+variable "disable_oathkeeper" {
+  description = "To not provision Oathkeeper, this is useful when you want multiple Kratos setup, while only 1 Oathkeeper proxy to route to them, for example sharing Oathkeeper between a Dev and Staging Kratos"
+  type        = bool
+  default     = false
+}
+
+variable "disable_frontend_https" {
+  description = "Whether frontend URLs should be https, unless your developing locally you should leave the default as is."
+  type        = bool
+  default     = false
+}

--- a/modules/user_auth/variables.tf
+++ b/modules/user_auth/variables.tf
@@ -100,8 +100,8 @@ variable "disable_oathkeeper" {
   default     = false
 }
 
-variable "disable_frontend_https" {
+variable "frontend_use_https" {
   description = "Whether frontend URLs should be https, unless your developing locally you should leave the default as is."
   type        = bool
-  default     = false
+  default     = true
 }


### PR DESCRIPTION
kratos redirect URLs are driven by config and are static,
this will allow spining up another instance of user_auth(kratos) without
oathkeeper, and allow the cookies to be sent cross-site
127.0.0.1:3000 -> backend on the cloud (for dev-env)
allow modifying scheme allowing dev-instance of kratos with localhost

## Description

Please explain the changes you made here and link to any relevant issues.

### Checklist

- [ ] Validation tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/commitdev/terraform-aws-zero/#doc-generation
