### PR TITLE
Enable image scan on push to aws_ecr

### DIFF
--- a/modules/ecr/main.tf
+++ b/modules/ecr/main.tf
@@ -5,6 +5,10 @@ resource "aws_ecr_repository" "ecr_repository" {
   tags = {
     environment = var.environment
   }
+  
+  image_scanning_configuration {
+    scan_on_push = true
+  }
 }
 
 data "aws_iam_policy_document" "ecr_fullaccess" {


### PR DESCRIPTION
## Description

Enable auto image scan for `aws_ecr` according to this [issue](https://github.com/commitdev/zero/issues/408)

### Checklist

- [ ] Validation tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/commitdev/terraform-aws-zero/#doc-generation
