### PR TITLE
fix: user-auth when external-secrets enabled

### DIFF
--- a/modules/user_auth/main.tf
+++ b/modules/user_auth/main.tf
@@ -19,6 +19,7 @@ locals {
   kratos_values_override = {
     secret = {
       nameOverride = var.kratos_secret_name
+      enabled = var.external_secret_backend == ""
     }
     kratos = {
       config = {


### PR DESCRIPTION
should disable kratos from creating secret, since it will conflict
when trying to create a helm-managed version

## Description

Please explain the changes you made here and link to any relevant issues.

### Checklist

- [ ] Validation tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/commitdev/terraform-aws-zero/#doc-generation
