### PR TITLE
EKS: Allow to customise log types and ensure update of instance types runs smoothly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
-- repo: git://github.com/antonbabenko/pre-commit-terraform
+- repo: https://github.com/antonbabenko/pre-commit-terraform
   rev: v1.39.0
   hooks:
     - id: terraform_fmt
     - id: terraform_docs
-- repo: git://github.com/pre-commit/pre-commit-hooks
-  rev: v3.2.0
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.4.0
   hooks:
     - id: check-merge-conflict

--- a/modules/eks/README.md
+++ b/modules/eks/README.md
@@ -52,12 +52,14 @@ Note: To fully enable prefix delegation, the ENABLE_PREFIX_DELEGATION environmen
 | addon\_coredns\_version | Version of CoreDNS to install. If empty you will need to upgrade CoreDNS yourself during a cluster version upgrade | `string` | `""` | no |
 | addon\_kube\_proxy\_version | Version of kube proxy to install. If empty you will need to upgrade kube proxy yourself during a cluster version upgrade | `string` | `""` | no |
 | addon\_vpc\_cni\_version | Version of the VPC CNI to install. If empty you will need to upgrade the CNI yourself during a cluster version upgrade | `string` | `""` | no |
+| cluster\_enabled\_log\_types | A list of the desired control plane logging to enable. For more information, see Amazon EKS Control Plane Logging documentation (https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html) | `list(string)` | `[]` | no |
 | cluster\_name | Name to be given to the EKS cluster | `any` | n/a | yes |
 | cluster\_version | EKS cluster version number to use. Incrementing this will start a cluster upgrade | `any` | n/a | yes |
 | eks\_node\_groups | Map of maps of EKS node group config where keys are node group names. See the readme for details. | `any` | n/a | yes |
 | environment | The environment (stage/prod) | `any` | n/a | yes |
 | force\_old\_cluster\_iam\_role\_name | Compatibility fix - If your cluster was created using a version of this module earlier than 0.4.3, this should be set to true. If the wrong value is set, you may see kubernetes connection issues when running terraform | `bool` | `false` | no |
 | iam\_account\_id | Account ID of the current IAM user | `any` | n/a | yes |
+| node\_group\_name\_as\_prefix | Use Node Group name as a prefix ? This allow to change instance types. | `bool` | `false` | no |
 | private\_subnets | VPC subnets for the EKS cluster | `list(string)` | n/a | yes |
 | project | Name of the project | `any` | n/a | yes |
 | vpc\_id | VPC ID for EKS cluster | `any` | n/a | yes |

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -59,6 +59,8 @@ module "eks" {
 
   write_kubeconfig = false
 
+  cluster_enabled_log_types = var.cluster_enabled_log_types
+
   tags = {
     environment = var.environment
   }

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -55,3 +55,9 @@ variable "force_old_cluster_iam_role_name" {
   type        = bool
   default     = false
 }
+
+variable "cluster_enabled_log_types" {
+  description = "A list of the desired control plane logging to enable. For more information, see Amazon EKS Control Plane Logging documentation (https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html)"
+  type        = list(string)
+  default     = []
+}

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -61,3 +61,9 @@ variable "cluster_enabled_log_types" {
   type        = list(string)
   default     = []
 }
+
+variable "node_group_name_as_prefix" {
+  description = "Use Node Group name as a prefix ? This allow to change instance types."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Description

Two changes on this pr:
- Allow to pass the AWS EKS  log types to be captured by CloudWatch
- Also change the EKS node groups to use name prefix, avoiding issue with node group recreation when changing the instance types.

### Checklist

- [ ] Validation tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/commitdev/terraform-aws-zero/#doc-generation
