### PR TITLE
Multiple improvements on EKS and logging stacks

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -28,7 +28,9 @@ jobs:
       id: init
       run: |
         for dir in modules/* ; do
+          echo "::group::Module $dir"
           pushd $dir && terraform init -backend=false && popd
+          echo "::endgroup::"
         done
 
     - name: Terraform Validate
@@ -38,7 +40,9 @@ jobs:
         AWS_REGION: 'us-east-1'
       run: |
         for dir in modules/* ; do
+          echo "::group::Module $dir"
           pushd $dir && terraform validate -no-color && popd
+          echo "::endgroup::"
         done
 
 

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -27,11 +27,14 @@ jobs:
     - name: Terraform Init
       id: init
       run: |
+        EXIT=0
         for dir in modules/* ; do
           echo "::group::Module $dir"
-          pushd $dir && terraform init -backend=false && popd
+          pushd $dir ; terraform init -backend=false ; E=$?; echo "Exit code: $E";popd
           echo "::endgroup::"
+          EXIT=$((E+EXIT))
         done
+        exit $EXIT
 
     - name: Terraform Validate
       id: validate
@@ -39,11 +42,14 @@ jobs:
         # Not used, but necessary as some sub-modules reference it.
         AWS_REGION: 'us-east-1'
       run: |
+        EXIT=0
         for dir in modules/* ; do
           echo "::group::Module $dir"
-          pushd $dir && terraform validate -no-color && popd
+          pushd $dir; terraform validate -no-color; E=$?; echo "Exit code: $E"; popd
           echo "::endgroup::"
+          EXIT=$((E+EXIT))
         done
+        exit $EXIT
 
 
     - uses: actions/github-script@0.9.0

--- a/modules/cache/README.md
+++ b/modules/cache/README.md
@@ -7,37 +7,50 @@ Create cache store (redis or memcached) cluster
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 5.0 |
 
 ## Providers
 
-No provider.
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_memcached"></a> [memcached](#module\_memcached) | cloudposse/elasticache-memcached/aws | 0.15.1 |
+| <a name="module_redis"></a> [redis](#module\_redis) | cloudposse/elasticache-redis/aws | 0.51.1 |
+
+## Resources
+
+No resources.
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| availability\_zones | Availability zone IDs | `list(string)` | `[]` | no |
-| cache\_store | Cache store - redis or memcached | `string` | n/a | yes |
-| cluster\_size | Number of nodes in cluster | `number` | `1` | no |
-| environment | The environment (stage/prod) | `any` | n/a | yes |
-| instance\_type | Elastic cache instance type | `string` | `"cache.t2.micro"` | no |
-| memcached\_engine\_version | Engine version | `string` | `"1.5.16"` | no |
-| project | Name of the project | `any` | n/a | yes |
-| redis\_engine\_version | Engine version | `string` | `"5.0.6"` | no |
-| redis\_family | Redis family | `string` | `"redis5.0"` | no |
-| redis\_transit\_encryption\_enabled | Enable TLS for redis | `bool` | `true` | no |
-| security\_groups | The ID of the security group created by default on Default VPC creation | `list(string)` | n/a | yes |
-| subnet\_ids | Subnets IDs | `list(string)` | n/a | yes |
-| vpc\_id | VPC ID for EKS cluster | `any` | n/a | yes |
+| <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | Availability zone IDs | `list(string)` | `[]` | no |
+| <a name="input_cache_store"></a> [cache\_store](#input\_cache\_store) | Cache store - redis or memcached | `string` | n/a | yes |
+| <a name="input_cluster_size"></a> [cluster\_size](#input\_cluster\_size) | Number of nodes in cluster | `number` | `1` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | The environment (stage/prod) | `any` | n/a | yes |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Elastic cache instance type | `string` | `"cache.t2.micro"` | no |
+| <a name="input_memcached_engine_version"></a> [memcached\_engine\_version](#input\_memcached\_engine\_version) | Engine version | `string` | `"1.5.16"` | no |
+| <a name="input_project"></a> [project](#input\_project) | Name of the project | `any` | n/a | yes |
+| <a name="input_redis_engine_version"></a> [redis\_engine\_version](#input\_redis\_engine\_version) | Engine version | `string` | `"5.0.6"` | no |
+| <a name="input_redis_family"></a> [redis\_family](#input\_redis\_family) | Redis family | `string` | `"redis5.0"` | no |
+| <a name="input_redis_transit_encryption_enabled"></a> [redis\_transit\_encryption\_enabled](#input\_redis\_transit\_encryption\_enabled) | Enable TLS for redis | `bool` | `true` | no |
+| <a name="input_security_groups"></a> [security\_groups](#input\_security\_groups) | The ID of the security group created by default on Default VPC creation | `list(string)` | n/a | yes |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Subnets IDs | `list(string)` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID for EKS cluster | `any` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| endpoint | Cache store address |
-| hostname | Cache store hostname |
-| id | Cache store ID |
-| port | Cache store port |
-
+| <a name="output_endpoint"></a> [endpoint](#output\_endpoint) | Cache store address |
+| <a name="output_hostname"></a> [hostname](#output\_hostname) | Cache store hostname |
+| <a name="output_id"></a> [id](#output\_id) | Cache store ID |
+| <a name="output_port"></a> [port](#output\_port) | Cache store port |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/cache/main.tf
+++ b/modules/cache/main.tf
@@ -2,7 +2,7 @@ module "redis" {
   count = var.cache_store == "redis" ? 1 : 0
 
   source  = "cloudposse/elasticache-redis/aws"
-  version = "0.43.0"
+  version = "0.51.1"
 
   name = "redis"
 

--- a/modules/cache/versions.tf
+++ b/modules/cache/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "< 5.0"
+    }
+  }
+}

--- a/modules/cloudtrail/README.md
+++ b/modules/cloudtrail/README.md
@@ -9,7 +9,9 @@ Enable CloudTrail logging for management and service events
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 5.0 |
+
 
 ## Providers
 

--- a/modules/cloudtrail/versions.tf
+++ b/modules/cloudtrail/versions.tf
@@ -1,4 +1,10 @@
-
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "< 5.0"
+    }
+  }
 }

--- a/modules/database/README.md
+++ b/modules/database/README.md
@@ -9,8 +9,8 @@ Create an RDS database.
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13 |
-| aws | >= 4.9 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 5.0 |
 
 ## Providers
 

--- a/modules/database/versions.tf
+++ b/modules/database/versions.tf
@@ -1,11 +1,11 @@
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9"
+      version = "< 5.0"
     }
   }
 }

--- a/modules/eks/README.md
+++ b/modules/eks/README.md
@@ -36,41 +36,56 @@ Note: To fully enable prefix delegation, the ENABLE_PREFIX_DELEGATION environmen
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13 |
-| aws | >= 3.37.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.37.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.37.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.37.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | 17.24.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_eks_addon.coredns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) | resource |
+| [aws_eks_addon.kube_proxy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) | resource |
+| [aws_eks_addon.vpc_cni](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| addon\_coredns\_version | Version of CoreDNS to install. If empty you will need to upgrade CoreDNS yourself during a cluster version upgrade | `string` | `""` | no |
-| addon\_kube\_proxy\_version | Version of kube proxy to install. If empty you will need to upgrade kube proxy yourself during a cluster version upgrade | `string` | `""` | no |
-| addon\_vpc\_cni\_version | Version of the VPC CNI to install. If empty you will need to upgrade the CNI yourself during a cluster version upgrade | `string` | `""` | no |
-| cluster\_enabled\_log\_types | A list of the desired control plane logging to enable. For more information, see Amazon EKS Control Plane Logging documentation (https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html) | `list(string)` | `[]` | no |
-| cluster\_name | Name to be given to the EKS cluster | `any` | n/a | yes |
-| cluster\_version | EKS cluster version number to use. Incrementing this will start a cluster upgrade | `any` | n/a | yes |
-| eks\_node\_groups | Map of maps of EKS node group config where keys are node group names. See the readme for details. | `any` | n/a | yes |
-| environment | The environment (stage/prod) | `any` | n/a | yes |
-| force\_old\_cluster\_iam\_role\_name | Compatibility fix - If your cluster was created using a version of this module earlier than 0.4.3, this should be set to true. If the wrong value is set, you may see kubernetes connection issues when running terraform | `bool` | `false` | no |
-| iam\_account\_id | Account ID of the current IAM user | `any` | n/a | yes |
-| node\_group\_name\_as\_prefix | Use Node Group name as a prefix ? This allow to change instance types. | `bool` | `false` | no |
-| private\_subnets | VPC subnets for the EKS cluster | `list(string)` | n/a | yes |
-| project | Name of the project | `any` | n/a | yes |
-| vpc\_id | VPC ID for EKS cluster | `any` | n/a | yes |
+| <a name="input_addon_coredns_version"></a> [addon\_coredns\_version](#input\_addon\_coredns\_version) | Version of CoreDNS to install. If empty you will need to upgrade CoreDNS yourself during a cluster version upgrade | `string` | `""` | no |
+| <a name="input_addon_kube_proxy_version"></a> [addon\_kube\_proxy\_version](#input\_addon\_kube\_proxy\_version) | Version of kube proxy to install. If empty you will need to upgrade kube proxy yourself during a cluster version upgrade | `string` | `""` | no |
+| <a name="input_addon_vpc_cni_version"></a> [addon\_vpc\_cni\_version](#input\_addon\_vpc\_cni\_version) | Version of the VPC CNI to install. If empty you will need to upgrade the CNI yourself during a cluster version upgrade | `string` | `""` | no |
+| <a name="input_cluster_enabled_log_types"></a> [cluster\_enabled\_log\_types](#input\_cluster\_enabled\_log\_types) | A list of the desired control plane logging to enable. For more information, see Amazon EKS Control Plane Logging documentation (https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html) | `list(string)` | `[]` | no |
+| <a name="input_cluster_log_retention_in_days"></a> [cluster\_log\_retention\_in\_days](#input\_cluster\_log\_retention\_in\_days) | Number of days to retain log events on CloudWatch logs from `cluster_enabled_log_types` | `number` | `90` | no |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name to be given to the EKS cluster | `any` | n/a | yes |
+| <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | EKS cluster version number to use. Incrementing this will start a cluster upgrade | `any` | n/a | yes |
+| <a name="input_eks_node_groups"></a> [eks\_node\_groups](#input\_eks\_node\_groups) | Map of maps of EKS node group config where keys are node group names. See the readme for details. | `any` | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | The environment (stage/prod) | `any` | n/a | yes |
+| <a name="input_force_old_cluster_iam_role_name"></a> [force\_old\_cluster\_iam\_role\_name](#input\_force\_old\_cluster\_iam\_role\_name) | Compatibility fix - If your cluster was created using a version of this module earlier than 0.4.3, this should be set to true. If the wrong value is set, you may see kubernetes connection issues when running terraform | `bool` | `false` | no |
+| <a name="input_iam_account_id"></a> [iam\_account\_id](#input\_iam\_account\_id) | Account ID of the current IAM user | `any` | n/a | yes |
+| <a name="input_node_group_name_as_prefix"></a> [node\_group\_name\_as\_prefix](#input\_node\_group\_name\_as\_prefix) | Use Node Group name as a prefix ? This allow to change instance types. | `bool` | `false` | no |
+| <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | VPC subnets for the EKS cluster | `list(string)` | n/a | yes |
+| <a name="input_project"></a> [project](#input\_project) | Name of the project | `any` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID for EKS cluster | `any` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| cluster\_id | Identifier of the EKS cluster |
-| worker\_iam\_role\_arn | The ARN of the EKS worker IAM role |
-| worker\_iam\_role\_name | The name of the EKS worker IAM role |
-| worker\_security\_group\_id | The security group of the EKS workers |
+| <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | Identifier of the EKS cluster |
+| <a name="output_worker_iam_role_arn"></a> [worker\_iam\_role\_arn](#output\_worker\_iam\_role\_arn) | The ARN of the EKS worker IAM role |
+| <a name="output_worker_iam_role_name"></a> [worker\_iam\_role\_name](#output\_worker\_iam\_role\_name) | The name of the EKS worker IAM role |
+| <a name="output_worker_security_group_id"></a> [worker\_security\_group\_id](#output\_worker\_security\_group\_id) | The security group of the EKS workers |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -25,9 +25,10 @@ locals {
         k8s_labels = {
           Environment = var.environment
         }
-        additional_tags = {
-          Environment = var.environment
-        }
+        additional_tags = merge(
+          { Environment = var.environment },
+          lookup(config, "additional_tags", {})
+        )
         taints = lookup(config, "taints", {})
     })
   }

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -35,7 +35,7 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "17.1.0"
+  version = "17.24.0"
 
   cluster_name    = var.cluster_name
   cluster_version = var.cluster_version
@@ -62,7 +62,8 @@ module "eks" {
 
   write_kubeconfig = false
 
-  cluster_enabled_log_types = var.cluster_enabled_log_types
+  cluster_enabled_log_types     = var.cluster_enabled_log_type
+  cluster_log_retention_in_days = var.cluster_log_retention_in_days
 
   tags = {
     environment = var.environment

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -62,7 +62,7 @@ module "eks" {
 
   write_kubeconfig = false
 
-  cluster_enabled_log_types     = var.cluster_enabled_log_type
+  cluster_enabled_log_types     = var.cluster_enabled_log_types
   cluster_log_retention_in_days = var.cluster_log_retention_in_days
 
   tags = {

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -62,6 +62,12 @@ variable "cluster_enabled_log_types" {
   default     = []
 }
 
+variable "cluster_log_retention_in_days" {
+  description = "Number of days to retain log events on CloudWatch logs from `cluster_enabled_log_types`"
+  type        = number
+  default     = 90
+}
+
 variable "node_group_name_as_prefix" {
   description = "Use Node Group name as a prefix ? This allow to change instance types."
   type        = bool

--- a/modules/logging/README.md
+++ b/modules/logging/README.md
@@ -9,37 +9,55 @@ Create an Elasticsearch cluster using AWS Elasticsearch for storing log data.
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_elasticsearch"></a> [elasticsearch](#module\_elasticsearch) | cloudposse/elasticsearch/aws | 0.44.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_log_group.application_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_log_group.index_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_log_group.search_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_log_resource_policy.elasticsearch_log_publishing_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_resource_policy) | resource |
+| [aws_iam_policy_document.elasticsearch_log_publishing_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| create\_service\_role | Set this to false if you already have an existing Elasticsearch cluster in this AWS account | `bool` | n/a | yes |
-| ebs\_volume\_size\_in\_gb | Size of EBS volume (in GB) to attach to *each* of the nodes in the cluster. The maximum size is limited by the size of the instance | `number` | n/a | yes |
-| elasticsearch\_enforce\_https | Set this to true to disallow unencrypted connections to Elasticsearch on port 80. Disabled by default as we are using kubernetes external services as user-friendly names to allow developers to connect to the cluster through the VPN. This would break if using HTTPS due to certificate issues. | `bool` | `false` | no |
-| elasticsearch\_version | Version of elasticsearch to use | `any` | n/a | yes |
-| enable\_cluster\_logging | If enabled, sends the logs from the elasticsearch cluster to Cloudwatch | `bool` | `false` | no |
-| environment | The environment (stage/prod) | `any` | n/a | yes |
-| instance\_count | Number of nodes in the cluster. Must be a multiple of the number of | `number` | n/a | yes |
-| instance\_type | Instance type for nodes | `any` | n/a | yes |
-| kibana\_subdomain\_name | The name of the subdomain for Kibana in the DNS zone (\_e.g.\_ `kibana`, `ui`, `ui-es`, `search-ui`, `kibana.elasticsearch`) | `string` | `"kibana"` | no |
-| project | The name of the project, mostly for tagging | `any` | n/a | yes |
-| security\_groups | Security groups to allow access from | `list(string)` | n/a | yes |
-| subnet\_ids | IDs of the subnets to put nodes in. The number of subnets here controls the number of nodes in the cluster, which must be a multiple of this number | `list(string)` | n/a | yes |
-| vpc\_id | ID of the VPC to create this cluster in | `any` | n/a | yes |
+| <a name="input_create_service_role"></a> [create\_service\_role](#input\_create\_service\_role) | Set this to false if you already have an existing Elasticsearch cluster in this AWS account | `bool` | n/a | yes |
+| <a name="input_ebs_iops"></a> [ebs\_iops](#input\_ebs\_iops) | The baseline input/output (I/O) performance of EBS volumes attached to data nodes. Applicable only for the Provisioned IOPS EBS volume type | `number` | `0` | no |
+| <a name="input_ebs_throughput"></a> [ebs\_throughput](#input\_ebs\_throughput) | Specifies the throughput (in MiB/s) of the EBS volumes attached to data nodes. Applicable only for the gp3 volume type. Valid values are between 125 and 1000. | `number` | `null` | no |
+| <a name="input_ebs_volume_size_in_gb"></a> [ebs\_volume\_size\_in\_gb](#input\_ebs\_volume\_size\_in\_gb) | Size of EBS volume (in GB) to attach to *each* of the nodes in the cluster. The maximum size is limited by the size of the instance | `number` | n/a | yes |
+| <a name="input_ebs_volume_type"></a> [ebs\_volume\_type](#input\_ebs\_volume\_type) | Storage type of EBS volumes for data | `string` | `"gp2"` | no |
+| <a name="input_elasticsearch_enforce_https"></a> [elasticsearch\_enforce\_https](#input\_elasticsearch\_enforce\_https) | Set this to true to disallow unencrypted connections to Elasticsearch on port 80. Disabled by default as we are using kubernetes external services as user-friendly names to allow developers to connect to the cluster through the VPN. This would break if using HTTPS due to certificate issues. | `bool` | `false` | no |
+| <a name="input_elasticsearch_version"></a> [elasticsearch\_version](#input\_elasticsearch\_version) | Version of elasticsearch to use | `any` | n/a | yes |
+| <a name="input_enable_cluster_logging"></a> [enable\_cluster\_logging](#input\_enable\_cluster\_logging) | If enabled, sends the logs from the elasticsearch cluster to Cloudwatch | `bool` | `false` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | The environment (stage/prod) | `any` | n/a | yes |
+| <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | Number of nodes in the cluster. Must be a multiple of the number of | `number` | n/a | yes |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type for nodes | `any` | n/a | yes |
+| <a name="input_kibana_subdomain_name"></a> [kibana\_subdomain\_name](#input\_kibana\_subdomain\_name) | The name of the subdomain for Kibana in the DNS zone (\_e.g.\_ `kibana`, `ui`, `ui-es`, `search-ui`, `kibana.elasticsearch`) | `string` | `"kibana"` | no |
+| <a name="input_project"></a> [project](#input\_project) | The name of the project, mostly for tagging | `any` | n/a | yes |
+| <a name="input_security_groups"></a> [security\_groups](#input\_security\_groups) | Security groups to allow access from | `list(string)` | n/a | yes |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | IDs of the subnets to put nodes in. The number of subnets here controls the number of nodes in the cluster, which must be a multiple of this number | `list(string)` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | ID of the VPC to create this cluster in | `any` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| elasticsearch\_endpoint | The internal hostname used to connect to Elasticsearch |
-| kibana\_endpoint | The URL used to connect to kibana (not including the https scheme) |
-
+| <a name="output_elasticsearch_endpoint"></a> [elasticsearch\_endpoint](#output\_elasticsearch\_endpoint) | The internal hostname used to connect to Elasticsearch |
+| <a name="output_kibana_endpoint"></a> [kibana\_endpoint](#output\_kibana\_endpoint) | The URL used to connect to kibana (not including the https scheme) |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/logging/main.tf
+++ b/modules/logging/main.tf
@@ -16,7 +16,7 @@ module "elasticsearch" {
   instance_count          = var.instance_count
   ebs_volume_size         = var.ebs_volume_size_in_gb
   ebs_volume_type         = var.ebs_volume_type
-  ebs_iops                = var.ebs_iops
+  ebs_iops                = var.ebs_volume_type != "gp2" ? var.ebs_iops : 0
   kibana_subdomain_name   = var.kibana_subdomain_name
   encrypt_at_rest_enabled = !can(regex("(?i)^(M3|R3|T2)", var.instance_type)) # These previous-generation instance types can't support encryption at rest
   iam_actions             = ["es:*"]

--- a/modules/logging/main.tf
+++ b/modules/logging/main.tf
@@ -2,7 +2,7 @@
 # After creating the infra, run the manifest in kubernetes/monitoring/ to set up fluentd
 module "elasticsearch" {
   source                  = "cloudposse/elasticsearch/aws"
-  version                 = "0.44.0"
+  version                 = "0.30.0"
   namespace               = var.project
   stage                   = var.environment
   name                    = "logging"
@@ -17,7 +17,6 @@ module "elasticsearch" {
   ebs_volume_size         = var.ebs_volume_size_in_gb
   ebs_volume_type         = var.ebs_volume_type
   ebs_iops                = var.ebs_iops
-  ebs_throughput          = var.ebs_throughput
   kibana_subdomain_name   = var.kibana_subdomain_name
   encrypt_at_rest_enabled = !can(regex("(?i)^(M3|R3|T2)", var.instance_type)) # These previous-generation instance types can't support encryption at rest
   iam_actions             = ["es:*"]

--- a/modules/logging/main.tf
+++ b/modules/logging/main.tf
@@ -2,7 +2,7 @@
 # After creating the infra, run the manifest in kubernetes/monitoring/ to set up fluentd
 module "elasticsearch" {
   source                  = "cloudposse/elasticsearch/aws"
-  version                 = "0.30.0"
+  version                 = "0.44.0"
   namespace               = var.project
   stage                   = var.environment
   name                    = "logging"
@@ -15,8 +15,11 @@ module "elasticsearch" {
   instance_type           = var.instance_type
   instance_count          = var.instance_count
   ebs_volume_size         = var.ebs_volume_size_in_gb
+  ebs_volume_type         = var.ebs_volume_type
+  ebs_iops                = var.ebs_iops
+  ebs_throughput          = var.ebs_throughput
   kibana_subdomain_name   = var.kibana_subdomain_name
-  encrypt_at_rest_enabled = ! can(regex("(?i)^(M3|R3|T2)", var.instance_type)) # These previous-generation instance types can't support encryption at rest
+  encrypt_at_rest_enabled = !can(regex("(?i)^(M3|R3|T2)", var.instance_type)) # These previous-generation instance types can't support encryption at rest
   iam_actions             = ["es:*"]
   iam_role_arns           = ["*"]
 

--- a/modules/logging/variables.tf
+++ b/modules/logging/variables.tf
@@ -59,12 +59,6 @@ variable "ebs_iops" {
   description = "The baseline input/output (I/O) performance of EBS volumes attached to data nodes. Applicable only for the Provisioned IOPS EBS volume type"
 }
 
-variable "ebs_throughput" {
-  type        = number
-  default     = null
-  description = "Specifies the throughput (in MiB/s) of the EBS volumes attached to data nodes. Applicable only for the gp3 volume type. Valid values are between 125 and 1000."
-}
-
 variable "enable_cluster_logging" {
   description = "If enabled, sends the logs from the elasticsearch cluster to Cloudwatch"
   type        = bool

--- a/modules/logging/variables.tf
+++ b/modules/logging/variables.tf
@@ -28,7 +28,7 @@ variable "instance_type" {
   description = "Instance type for nodes"
 
   validation {
-    condition     = can(regex("^[[:alpha:]][[:digit:]]\\..*\\.elasticsearch$", var.instance_type))
+    condition     = can(regex("^[[:alpha:]][[:digit:]][[:alpha:]]?\\..*\\.elasticsearch$", var.instance_type))
     error_message = "The instance_type variable must contain a valid elasticsearch instance type."
   }
 }
@@ -46,6 +46,23 @@ variable "instance_count" {
 variable "ebs_volume_size_in_gb" {
   description = "Size of EBS volume (in GB) to attach to *each* of the nodes in the cluster. The maximum size is limited by the size of the instance"
   type        = number
+}
+
+variable "ebs_volume_type" {
+  description = "Storage type of EBS volumes for data"
+  type        = string
+  default     = "gp2"
+}
+variable "ebs_iops" {
+  type        = number
+  default     = 0
+  description = "The baseline input/output (I/O) performance of EBS volumes attached to data nodes. Applicable only for the Provisioned IOPS EBS volume type"
+}
+
+variable "ebs_throughput" {
+  type        = number
+  default     = null
+  description = "Specifies the throughput (in MiB/s) of the EBS volumes attached to data nodes. Applicable only for the gp3 volume type. Valid values are between 125 and 1000."
 }
 
 variable "enable_cluster_logging" {

--- a/modules/logging/variables.tf
+++ b/modules/logging/variables.tf
@@ -55,8 +55,8 @@ variable "ebs_volume_type" {
 }
 variable "ebs_iops" {
   type        = number
-  default     = 0
-  description = "The baseline input/output (I/O) performance of EBS volumes attached to data nodes. Applicable only for the Provisioned IOPS EBS volume type"
+  default     = 3000
+  description = "The baseline input/output (I/O) performance of EBS volumes attached to data nodes. Applicable only for the Provisioned IOPS EBS volume type when not `gp2`"
 }
 
 variable "enable_cluster_logging" {

--- a/modules/sendgrid/README.md
+++ b/modules/sendgrid/README.md
@@ -13,26 +13,43 @@ This implementation relies on a bash-script to fetch the CNAMEs required for sen
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
-| external | n/a |
-| null | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.13.1 |
+| <a name="provider_external"></a> [external](#provider\_external) | 2.3.1 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.1 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_route53_record.dns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [null_resource.domain_verification](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [aws_route53_zone.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
+| [aws_secretsmanager_secret_version.sendgrid_api_key_secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
+| [external_external.sendgrid_route53_cnames](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| sendgrid\_api\_key\_secret\_name | name of the secret in AWS secret manager that contains the sendgrid API key | `any` | n/a | yes |
-| sendgrid\_domain\_prefix | prefix for mailing domain used by sendgrid | `string` | `""` | no |
-| zone\_name | route53 zone for CNAME records to be created | `string` | n/a | yes |
+| <a name="input_sendgrid_api_key_secret_name"></a> [sendgrid\_api\_key\_secret\_name](#input\_sendgrid\_api\_key\_secret\_name) | name of the secret in AWS secret manager that contains the sendgrid API key | `any` | n/a | yes |
+| <a name="input_sendgrid_domain_prefix"></a> [sendgrid\_domain\_prefix](#input\_sendgrid\_domain\_prefix) | prefix for mailing domain used by sendgrid | `string` | `""` | no |
+| <a name="input_zone_name"></a> [zone\_name](#input\_zone\_name) | route53 zone for CNAME records to be created | `string` | n/a | yes |
 
 ## Outputs
 
-No output.
+No outputs.
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/sendgrid/versions.tf
+++ b/modules/sendgrid/versions.tf
@@ -1,0 +1,11 @@
+
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "< 5.0"
+    }
+  }
+}

--- a/modules/user_access/README.md
+++ b/modules/user_access/README.md
@@ -9,25 +9,41 @@ Create IAM Roles/Groups and Kubernetes Cluster Roles for user access
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.13.1 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_group.access_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group) | resource |
+| [aws_iam_group_policy_attachment.access_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group_policy_attachment) | resource |
+| [aws_iam_policy.access_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_user_group_membership.access_user_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_group_membership) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.access_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| environment | The environment (stage/prod) | `any` | n/a | yes |
-| project | Name of the project | `any` | n/a | yes |
-| roles | Roles to create with associated aws policies | <pre>list(object({<br>    name       = string<br>    aws_policy = string<br>  }))</pre> | n/a | yes |
-| users | Users to create with associated roles, mapping to the ones defined in the roles variable | <pre>list(object({<br>    name  = string<br>    roles = list(string)<br>  }))</pre> | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | The environment (stage/prod) | `any` | n/a | yes |
+| <a name="input_project"></a> [project](#input\_project) | Name of the project | `any` | n/a | yes |
+| <a name="input_roles"></a> [roles](#input\_roles) | Roles to create with associated aws policies | <pre>list(object({<br>    name       = string<br>    aws_policy = string<br>  }))</pre> | n/a | yes |
+| <a name="input_users"></a> [users](#input\_users) | Users to create with associated roles, mapping to the ones defined in the roles variable | <pre>list(object({<br>    name  = string<br>    roles = list(string)<br>  }))</pre> | n/a | yes |
 
 ## Outputs
 
-No output.
+No outputs.
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/user_access/versions.tf
+++ b/modules/user_access/versions.tf
@@ -1,4 +1,11 @@
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "< 5.0"
+    }
+  }
 }

--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -9,13 +9,14 @@ Create a VPC for a specific environment, all other resources will be created ins
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.13.1 |
 
 ## Modules
 

--- a/modules/vpc/versions.tf
+++ b/modules/vpc/versions.tf
@@ -1,4 +1,11 @@
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "< 5.0"
+    }
+  }
 }


### PR DESCRIPTION
Improve the following:
- EKS: 
  - Support for custom log retention using Cloudwatch
  - Allow to pass custom AWS Tags to EKS Nodes
  - Bump TF Module to latest minor from major version used.
- Logging:
  - Bump version of ElasticSeach module
  - Set IOPS when not GP2 volume
  - Allow to change instance types
- Cache (Redis)
  - bumped version of module used
  - Pinned the TF and AWS provider versions to avoid breaking changes.
- Many of the submodules
  - Pinned the TF and AWS provider versions to avoid breaking changes.